### PR TITLE
feat: support debug logging when `showVerboseMessages` is off

### DIFF
--- a/packages/config-tv/src/utils.ts
+++ b/packages/config-tv/src/utils.ts
@@ -1,3 +1,4 @@
+import { WarningAggregator } from 'expo/config-plugins';
 import { boolish } from 'getenv';
 
 import { ConfigData } from './types';
@@ -9,7 +10,13 @@ class Env {
   }
 }
 
+const debug = require('debug')(
+  'expo:react-native-tvos:config-tv',
+) as typeof console.log;
+
 const env = new Env();
+
+const pkg = require('../package.json');
 
 const defaultTvosDeploymentVersion = '13.4';
 
@@ -27,4 +34,25 @@ export function tvosDeploymentTarget(params: ConfigData): string {
 
 export function shouldRemoveFlipperOnAndroid(params: ConfigData): boolean {
   return params?.removeFlipperOnAndroid ?? true;
+}
+
+export function verboseLog(
+  message: string,
+  options: {
+    params: ConfigData;
+    platform: 'android' | 'ios';
+    property: string;
+  },
+) {
+  const { params, platform, property } = options;
+  const verbose = showVerboseWarnings(params);
+  if (verbose) {
+    WarningAggregator.addWarningForPlatform(
+      platform,
+      property,
+      `${pkg.name}@${pkg.version}: ${message}`,
+    );
+  } else {
+    debug(`${property}: ${message}`);
+  }
 }

--- a/packages/config-tv/src/withTVAndroidRemoveFlipper.ts
+++ b/packages/config-tv/src/withTVAndroidRemoveFlipper.ts
@@ -1,22 +1,10 @@
-import {
-  mergeContents,
-  removeContents,
-} from '@expo/config-plugins/build/utils/generateCode';
-import {
-  ConfigPlugin,
-  WarningAggregator,
-  withDangerousMod,
-} from 'expo/config-plugins';
+import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
 import { promises } from 'fs';
 import glob from 'glob';
 import path from 'path';
 
 import { ConfigData } from './types';
-import {
-  isTVEnabled,
-  shouldRemoveFlipperOnAndroid,
-  showVerboseWarnings,
-} from './utils';
+import { isTVEnabled, shouldRemoveFlipperOnAndroid, verboseLog } from './utils';
 
 const pkg = require('../package.json');
 
@@ -26,7 +14,6 @@ export const withTVAndroidRemoveFlipper: ConfigPlugin<ConfigData> = (
   params = {},
 ) => {
   const isTV = isTVEnabled(params);
-  const verbose = showVerboseWarnings(params);
   const androidRemoveFlipper = shouldRemoveFlipperOnAndroid(params);
 
   return withDangerousMod(c, [
@@ -38,12 +25,11 @@ export const withTVAndroidRemoveFlipper: ConfigPlugin<ConfigData> = (
         const mainApplicationFile = mainApplicationFilePath(
           config.modRequest.platformProjectRoot,
         );
-        if (verbose) {
-          WarningAggregator.addWarningAndroid(
-            'source',
-            `${pkg.name}@${pkg.version}: removing Flipper from MainApplication file`,
-          );
-        }
+        verboseLog('removing Flipper from MainApplication file', {
+          params,
+          platform: 'android',
+          property: 'manifest',
+        });
         const mainApplicationContents = await promises.readFile(
           mainApplicationFile,
           'utf8',
@@ -62,12 +48,11 @@ export const withTVAndroidRemoveFlipper: ConfigPlugin<ConfigData> = (
         const buildGradleFile = appBuildGradleFilePath(
           config.modRequest.platformProjectRoot,
         );
-        if (verbose) {
-          WarningAggregator.addWarningAndroid(
-            'source',
-            `${pkg.name}@${pkg.version}: removing Flipper from android/app/build.gradle`,
-          );
-        }
+        verboseLog('removing Flipper from android/app/build.gradle', {
+          params,
+          platform: 'android',
+          property: 'manifest',
+        });
         const buildGradleContents = await promises.readFile(
           buildGradleFile,
           'utf-8',

--- a/packages/config-tv/src/withTVPodfile.ts
+++ b/packages/config-tv/src/withTVPodfile.ts
@@ -1,74 +1,66 @@
 import {
   mergeContents,
   removeContents,
-} from "@expo/config-plugins/build/utils/generateCode";
-import {
-  ConfigPlugin,
-  WarningAggregator,
-  withDangerousMod,
-} from "expo/config-plugins";
-import { promises } from "fs";
-import path from "path";
+} from '@expo/config-plugins/build/utils/generateCode';
+import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
+import { promises } from 'fs';
+import path from 'path';
 
-import { ConfigData } from "./types";
-import { isTVEnabled, showVerboseWarnings } from "./utils";
+import { ConfigData } from './types';
+import { isTVEnabled, verboseLog } from './utils';
 
-const pkg = require("../package.json");
+const pkg = require('../package.json');
 
 /** Dangerously makes or reverts TV changes in the project Podfile. */
 export const withTVPodfile: ConfigPlugin<ConfigData> = (c, params = {}) => {
   const isTV = isTVEnabled(params);
-  const verbose = showVerboseWarnings(params);
 
   return withDangerousMod(c, [
-    "ios",
+    'ios',
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     async (config) => {
-      const file = path.join(config.modRequest.platformProjectRoot, "Podfile");
+      const file = path.join(config.modRequest.platformProjectRoot, 'Podfile');
 
-      const contents = await promises.readFile(file, "utf8");
+      const contents = await promises.readFile(file, 'utf8');
 
       const modifiedContents = isTV
         ? addTVPodfileModifications(contents)
         : removeTVPodfileModifications(contents);
 
       if (modifiedContents !== contents) {
-        if (verbose) {
-          WarningAggregator.addWarningIOS(
-            "podfile",
-            `${pkg.name}@${pkg.version}: modifying Podfile for ${
-              isTV ? "tvOS" : "iOS"
-            }`
-          );
-        }
-        await promises.writeFile(file, modifiedContents, "utf-8");
+        verboseLog(`modifying Podfile for ${isTV ? 'tvOS' : 'iOS'}`, {
+          params,
+          platform: 'ios',
+          property: 'podfile',
+        });
+        await promises.writeFile(file, modifiedContents, 'utf-8');
       }
       return config;
     },
   ]);
 };
 
-const MOD_TAG = "react-native-tvos-import";
+const MOD_TAG = 'react-native-tvos-import';
 
 export function removeTVPodfileModifications(src: string): string {
-  if (src.indexOf("platform :tvos") === -1) {
+  if (src.indexOf('platform :tvos') === -1) {
     return src;
   }
-  const intermediateSrc = src.replace("platform :tvos", "platform :ios");
+  const intermediateSrc = src.replace('platform :tvos', 'platform :ios');
   const newSrc = removeContents({
     src: intermediateSrc,
     tag: MOD_TAG,
   }).contents;
   if (!newSrc) {
     throw new Error(
-      `${pkg.name}@${pkg.version}: Error in removing TV modifications from Podfile. Recommend running "npx expo prebuild --clean"`
+      `${pkg.name}@${pkg.version}: Error in removing TV modifications from Podfile. Recommend running "npx expo prebuild --clean"`,
     );
   }
   return newSrc;
 }
 
 export function addTVPodfileModifications(src: string): string {
-  if (src.indexOf("platform :tvos") !== -1) {
+  if (src.indexOf('platform :tvos') !== -1) {
     return src;
   }
   const newSrc = mergeContents({
@@ -78,8 +70,8 @@ export function addTVPodfileModifications(src: string): string {
       "source 'https://github.com/react-native-tvos/react-native-tvos-podspecs.git'\nsource 'https://cdn.cocoapods.org/'\n",
     anchor: /^/,
     offset: 0,
-    comment: "#",
+    comment: '#',
   }).contents;
 
-  return newSrc.replace("platform :ios", "platform :tvos");
+  return newSrc.replace('platform :ios', 'platform :tvos');
 }


### PR DESCRIPTION
- All plugins now log verbose messages using new `verboseLog()` method in `utils.ts`
- If the verbose plugin property is true, log using `WarningAggregator` (as before this change)
- If the verbose plugin property is false, use the `debug` facility to log
  - In this case, debug messages will be visible if we set `DEBUG=expo:react-native-tvos:config-tv` or `EXPO_DEBUG=1`