### PR TITLE
Add TV banner image to Android

### DIFF
--- a/packages/config-tv/src/__tests__/withTV-test.ts
+++ b/packages/config-tv/src/__tests__/withTV-test.ts
@@ -1,31 +1,32 @@
-import { AndroidConfig } from "@expo/config-plugins";
-import { resolve } from "path";
+import { AndroidConfig } from '@expo/config-plugins';
+import { resolve } from 'path';
 
 import {
   removePortraitOrientation,
   setLeanBackLauncherIntent,
-} from "../withTVAndroidManifest";
+  setTVBanner,
+} from '../withTVAndroidManifest';
 import {
   addTVPodfileModifications,
   removeTVPodfileModifications,
-} from "../withTVPodfile";
+} from '../withTVPodfile';
 import {
   addTVSplashScreenModifications,
   removeTVSplashScreenModifications,
-} from "../withTVSplashScreen";
+} from '../withTVSplashScreen';
 
 const { readAndroidManifestAsync } = AndroidConfig.Manifest;
 
 const sampleManifestPath = resolve(
   __dirname,
-  "./fixtures",
-  "react-native-AndroidManifest.xml"
+  './fixtures',
+  'react-native-AndroidManifest.xml',
 );
 
 const sampleManifestWithNoMainIntentPath = resolve(
   __dirname,
-  "./fixtures",
-  "react-native-AndroidManifestWithNoMainIntent.xml"
+  './fixtures',
+  'react-native-AndroidManifestWithNoMainIntent.xml',
 );
 
 const originalPodfile = `
@@ -78,22 +79,22 @@ const originalSplashScreen = `
 </document>
 `;
 
-describe("withTV iOS/tvOS tests", () => {
-  test("Add TV Podfile changes", () => {
+describe('withTV iOS/tvOS tests', () => {
+  test('Add TV Podfile changes', () => {
     const modifiedPodfile = addTVPodfileModifications(originalPodfile);
     expect(modifiedPodfile).toMatchSnapshot();
   });
-  test("Revert TV podfile changes", () => {
+  test('Revert TV podfile changes', () => {
     const modifiedPodfile = addTVPodfileModifications(originalPodfile);
     const revertedPodfile = removeTVPodfileModifications(modifiedPodfile);
     expect(revertedPodfile).toEqual(originalPodfile);
   });
-  test("Add TV splash screen changes", () => {
+  test('Add TV splash screen changes', () => {
     const modifiedSplashScreen =
       addTVSplashScreenModifications(originalSplashScreen);
     expect(modifiedSplashScreen).toMatchSnapshot();
   });
-  test("Revert TV splash screen changes", () => {
+  test('Revert TV splash screen changes', () => {
     const modifiedSplashScreen =
       addTVSplashScreenModifications(originalSplashScreen);
     const revertedSplashScreen =
@@ -102,41 +103,61 @@ describe("withTV iOS/tvOS tests", () => {
   });
 });
 
-describe("with TV Android tests", () => {
-  test("Adds leanback launcher intent category for TV builds", async () => {
+describe('with TV Android tests', () => {
+  test('Adds leanback launcher intent category for TV builds', async () => {
     const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
-    const modifiedManifest = setLeanBackLauncherIntent(
-      {},
-      originalManifest,
-      false
-    );
-    expect(JSON.stringify(modifiedManifest).indexOf("LEANBACK")).not.toEqual(
-      -1
+    const modifiedManifest = setLeanBackLauncherIntent({}, originalManifest, {
+      isTV: true,
+      showVerboseWarnings: false,
+    });
+    expect(JSON.stringify(modifiedManifest).indexOf('LEANBACK')).not.toEqual(
+      -1,
     );
   });
-  test("Throws if manifest has no main intent", async () => {
+  test('Adds TV banner to main application', async () => {
+    const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
+    const modifiedManifest = setTVBanner(
+      {},
+      originalManifest,
+      {
+        isTV: true,
+        showVerboseWarnings: false,
+      },
+      'bogus',
+    );
+    expect(
+      JSON.stringify(modifiedManifest).indexOf('android:banner'),
+    ).not.toEqual(-1);
+  });
+  test('Throws if manifest has no main intent', async () => {
     const originalManifest = await readAndroidManifestAsync(
-      sampleManifestWithNoMainIntentPath
+      sampleManifestWithNoMainIntentPath,
     );
     try {
-      setLeanBackLauncherIntent({}, originalManifest, false);
+      setLeanBackLauncherIntent({}, originalManifest, {
+        isTV: true,
+        showVerboseWarnings: false,
+      });
       // Should not reach this line
       expect(true).toBe(false);
     } catch (e) {
       expect(e.message).toContain(
-        "no main intent in main activity of Android manifest"
+        'no main intent in main activity of Android manifest',
       );
     }
   });
-  test("Removes orientation from activity metadata for TV builds", async () => {
+  test('Removes orientation from activity metadata for TV builds', async () => {
     const originalManifest = await readAndroidManifestAsync(sampleManifestPath);
     const modifiedManifest = await removePortraitOrientation(
       {},
       originalManifest,
-      false
+      {
+        isTV: false,
+        showVerboseWarnings: false,
+      },
     );
     expect(
-      JSON.stringify(modifiedManifest).indexOf("screenOrientation")
+      JSON.stringify(modifiedManifest).indexOf('screenOrientation'),
     ).toEqual(-1);
   });
 });

--- a/packages/config-tv/src/types.ts
+++ b/packages/config-tv/src/types.ts
@@ -18,4 +18,11 @@ export type ConfigData = {
    * If set, Android code that references Flipper will be removed. (Defaults to true.)
    */
   removeFlipperOnAndroid?: boolean;
+  /**
+   * If set, this should be a path to an existing PNG file appropriate for an Android TV banner image.
+   * See https://developer.android.com/design/ui/tv/guides/system/tv-app-icon-guidelines#banner
+   * The Android manifest will be modified to reference this image, and the image will be copied into
+   * Android resource drawable directories.
+   */
+  androidTVBanner?: string;
 };

--- a/packages/config-tv/src/utils.ts
+++ b/packages/config-tv/src/utils.ts
@@ -36,6 +36,10 @@ export function shouldRemoveFlipperOnAndroid(params: ConfigData): boolean {
   return params?.removeFlipperOnAndroid ?? true;
 }
 
+export function androidTVBanner(params: ConfigData): string | undefined {
+  return params?.androidTVBanner;
+}
+
 export function verboseLog(
   message: string,
   options: {

--- a/packages/config-tv/src/withTV.ts
+++ b/packages/config-tv/src/withTV.ts
@@ -6,11 +6,13 @@ import { withTVPodfile } from './withTVPodfile';
 import { withTVSplashScreen } from './withTVSplashScreen';
 import { withTVXcodeProject } from './withTVXcodeProject';
 import { withTVAndroidRemoveFlipper } from './withTVAndroidRemoveFlipper';
+import { withTVAndroidBannerImage } from './withTVAndroidBannerImage';
 
 const withTVPlugin: ConfigPlugin<ConfigData> = (config, params = {}) => {
   config = withTVXcodeProject(config, params);
   config = withTVPodfile(config, params);
   config = withTVSplashScreen(config, params);
+  config = withTVAndroidBannerImage(config, params); // This should be done before Android manifest config
   config = withTVAndroidManifest(config, params);
   config = withTVAndroidRemoveFlipper(config, params);
 

--- a/packages/config-tv/src/withTVAndroidBannerImage.ts
+++ b/packages/config-tv/src/withTVAndroidBannerImage.ts
@@ -1,0 +1,70 @@
+import {
+  ConfigPlugin,
+  WarningAggregator,
+  withDangerousMod,
+} from 'expo/config-plugins';
+import { existsSync, promises } from 'fs';
+import path from 'path';
+
+import { ConfigData } from './types';
+import { isTVEnabled, showVerboseWarnings, androidTVBanner } from './utils';
+
+const pkg = require('../package.json');
+
+const drawableDirectoryNames = [
+  'drawable',
+  'drawable-hdpi',
+  'drawable-mdpi',
+  'drawable-xhdpi',
+  'drawable-xxhdpi',
+  'drawable-xxxhdpi',
+];
+
+/** Copies TV banner image to the Android resources drawable folders. If image does not exist, throw an exception. */
+export const withTVAndroidBannerImage: ConfigPlugin<ConfigData> = (
+  c,
+  params = {},
+) => {
+  const isTV = isTVEnabled(params);
+  const verbose = showVerboseWarnings(params);
+  const androidTVBannerPath = androidTVBanner(params);
+
+  return withDangerousMod(c, [
+    'android',
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    async (config) => {
+      if (!isTV) {
+        return config;
+      }
+      if (!androidTVBannerPath) {
+        return config;
+      }
+
+      if (verbose) {
+        WarningAggregator.addWarningAndroid(
+          'manifest',
+          `${pkg.name}@${pkg.version}: adding TV banner image ${androidTVBannerPath} to Android resources`,
+        );
+      }
+
+      for (const drawableDirectoryName of drawableDirectoryNames) {
+        const drawableDirectoryPath = path.join(
+          config.modRequest.platformProjectRoot,
+          'app',
+          'src',
+          'main',
+          'res',
+          drawableDirectoryName,
+        );
+        if (!existsSync(drawableDirectoryPath)) {
+          await promises.mkdir(drawableDirectoryPath);
+        }
+        await promises.copyFile(
+          androidTVBannerPath,
+          path.join(drawableDirectoryPath, 'tv_banner.png'),
+        );
+      }
+      return config;
+    },
+  ]);
+};


### PR DESCRIPTION
- Add new plugin property `androidTVBanner`
- This must be a path to a PNG file in the source tree
- When present, the plugin will set the `android:banner` attribute in the `AndroidManifest.xml` main application metadata, and copy the banner image to all the drawable directories in the Android resource folder (creating directories that don't exist)

Fixes #6 