### PR TITLE
fix: duplicate resource for Android TV icon

### DIFF
--- a/packages/config-tv/src/withTVAndroidIconImage.ts
+++ b/packages/config-tv/src/withTVAndroidIconImage.ts
@@ -57,10 +57,13 @@ export const withTVAndroidIconImage: ConfigPlugin<ConfigData> = (
             path.join(drawableDirectoryPath, "tv_icon.png"),
           );
         } else {
-          await promises.copyFile(
-            androidTVIconPath,
-            path.join(drawableDirectoryPath, "ic_launcher.png"),
-          );
+          // SDK 52 adds a webp ic_launcher, which could lead to duplicate resource build error
+          if (!existsSync(path.join(drawableDirectoryPath, "ic_launcher.webp"))) {
+            await promises.copyFile(
+              androidTVIconPath,
+              path.join(drawableDirectoryPath, "ic_launcher.png"),
+            );
+          }
           await promises.copyFile(
             androidTVIconPath,
             path.join(drawableDirectoryPath, "ic_launcher_round.png"),


### PR DESCRIPTION
After the Expo SDK 52 change in Android icon generation (https://github.com/expo/expo/pull/32908), the config-tv Android TV icon plugin adds a duplicate resource for `ic_launcher`, leading to a build error.

We fix this by checking for the existence of the new Expo SDK file, and do not copy our file if the webp file exists.