### PR TITLE
Fix ic_launcher_round duplication

### DIFF
--- a/packages/config-tv/src/withTVAndroidIconImage.ts
+++ b/packages/config-tv/src/withTVAndroidIconImage.ts
@@ -64,10 +64,12 @@ export const withTVAndroidIconImage: ConfigPlugin<ConfigData> = (
               path.join(drawableDirectoryPath, "ic_launcher.png"),
             );
           }
-          await promises.copyFile(
-            androidTVIconPath,
-            path.join(drawableDirectoryPath, "ic_launcher_round.png"),
-          );
+          if (!existsSync(path.join(drawableDirectoryPath, "ic_launcher_round.webp"))) {
+            await promises.copyFile(
+                androidTVIconPath,
+                path.join(drawableDirectoryPath, "ic_launcher_round.png"),
+            );
+          }
         }
       }
       return config;


### PR DESCRIPTION
Run into a similar issue as #28, but with rounded launcher images. This PR fixes the issue.

Expo: 52.0.23
react-native-tvos: 0.76.5-0

This was the error for future reference:

```
Execution failed for task ':app:mergeReleaseResources'.
> [mipmap-mdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png      [mipmap-mdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.webp: Error: Duplicate resources
  [mipmap-hdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png      [mipmap-hdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.webp: Error: Duplicate resources
  [mipmap-xxxhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png        [mipmap-xxxhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.webp: Error: Duplicate resources
  [mipmap-xxhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png  [mipmap-xxhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.webp: Error: Duplicate resources
  [mipmap-xhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png    [mipmap-xhdpi-v4/ic_launcher_round] expo/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.webp: Error: Duplicate resources
  ```
  
 