### PR TITLE
fix: remove unneeded podspec source for TV

### DIFF
--- a/packages/config-tv/src/__tests__/__snapshots__/withTV-test.ts.snap
+++ b/packages/config-tv/src/__tests__/__snapshots__/withTV-test.ts.snap
@@ -1,12 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`withTV iOS/tvOS tests Add TV Podfile changes 1`] = `
-"# @generated begin react-native-tvos-import - expo prebuild (DO NOT MODIFY) sync-45ad7228312d07c1751c6969560a210e8ec46f80
-source 'https://github.com/react-native-tvos/react-native-tvos-podspecs.git'
-source 'https://cdn.cocoapods.org/'
-
-# @generated end react-native-tvos-import
-
+"
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 

--- a/packages/config-tv/src/withTVPodfile.ts
+++ b/packages/config-tv/src/withTVPodfile.ts
@@ -30,12 +30,14 @@ export const withTVPodfile: ConfigPlugin<ConfigData> = (c, params = {}) => {
   ]);
 };
 
-const MOD_TAG = "react-native-tvos-import";
+// const MOD_TAG = "react-native-tvos-import";
 
 export function addTVPodfileModifications(src: string): string {
   if (src.indexOf("platform :tvos") !== -1) {
     return src;
   }
+  // We no longer need the custom podspecs source
+  /*
   const newSrc = mergeContents({
     tag: MOD_TAG,
     src,
@@ -45,6 +47,6 @@ export function addTVPodfileModifications(src: string): string {
     offset: 0,
     comment: "#",
   }).contents;
-
-  return newSrc.replace("platform :ios", "platform :tvos");
+   */
+  return src.replace("platform :ios", "platform :tvos");
 }


### PR DESCRIPTION
The custom podspecs were used in older versions of RNTV (0.71 and earlier), so we should not add this source when the plugin modifies the project Podfile.