### PR TITLE
fix: ensure tvOS icon assets are used in Xcode project

### DIFF
--- a/packages/config-tv/src/withTVXcodeProject.ts
+++ b/packages/config-tv/src/withTVXcodeProject.ts
@@ -57,9 +57,8 @@ export function setXcodeProjectBuildSettings(
       }
       if (params.appleTVImages) {
         // set the app icon source
-        if (buildSettings.ASSETCATALOG_COMPILER_APPICON_NAME === "AppIcon") {
-          buildSettings.ASSETCATALOG_COMPILER_APPICON_NAME = "TVAppIcon";
-        }
+        buildSettings.ASSETCATALOG_COMPILER_APPICON_NAME = "TVAppIcon";
+        buildSettings.ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = "YES";
       }
     }
   }


### PR DESCRIPTION
The new Expo SDK 55 default template has a different name for the icon asset referenced in the Xcode project.

Adjust the plugin to replace it (regardless of original name) with the TVAppIcon imageset if the user has set that in the plugin properties.