### PR TITLE
fix: Move `glob` dependency and remove unused imports

### DIFF
--- a/packages/config-tv/package.json
+++ b/packages/config-tv/package.json
@@ -39,12 +39,12 @@
   "devDependencies": {
     "@types/getenv": "^1.0.1",
     "expo-module-scripts": "^3.0.3",
-    "glob": "^11.0.0",
     "jest": "^29.7.0",
     "memfs": "^4.7.6"
   },
   "upstreamPackage": "tv",
   "dependencies": {
-    "getenv": "^1.0.0"
+    "getenv": "^1.0.0",
+    "glob": "^11.0.0"
   }
 }

--- a/packages/config-tv/src/__tests__/withTV-test.ts
+++ b/packages/config-tv/src/__tests__/withTV-test.ts
@@ -1,4 +1,4 @@
-import { AndroidConfig } from "@expo/config-plugins";
+import { AndroidConfig } from "expo/config-plugins";
 import { promises as fs } from "fs";
 import { vol } from "memfs";
 import { join, resolve } from "path";

--- a/packages/config-tv/src/withTVPodfile.ts
+++ b/packages/config-tv/src/withTVPodfile.ts
@@ -1,4 +1,3 @@
-import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
 import { ConfigPlugin, withDangerousMod } from "expo/config-plugins";
 import { promises } from "fs";
 import path from "path";
@@ -38,7 +37,7 @@ export function addTVPodfileModifications(src: string): string {
   }
   // We no longer need the custom podspecs source
   /*
-  const newSrc = mergeContents({
+  const newSrc = CodeGenerator.mergeContents({
     tag: MOD_TAG,
     src,
     newSrc:

--- a/packages/config-tv/src/withTVXcodeProject.ts
+++ b/packages/config-tv/src/withTVXcodeProject.ts
@@ -1,4 +1,3 @@
-import { ExpoConfig } from "@expo/config-types";
 import {
   ConfigPlugin,
   ExportedConfigWithProps,


### PR DESCRIPTION
## Summary

The `glob` dependency was accidentally in `devDependencies` and undeclared in installations. Some imports are for undeclared dependencies too, but luckily none of them are used as values in the built output, it seems.

## Set of changes

- Move `glob` to `dependencies`
- Remove unused `@expo/config-plugins/build/utils/generateCode` import
- Remove unused `@expo/config-types`
- Update import in tests for public API