### PR TITLE
feat: fall back to iOS deployment target for tvOS deployment target

### DIFF
--- a/packages/config-tv/src/__tests__/withTV-test.ts
+++ b/packages/config-tv/src/__tests__/withTV-test.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from "expo/config";
 import { AndroidConfig } from "expo/config-plugins";
 import { promises as fs } from "fs";
 import { vol } from "memfs";
@@ -13,6 +14,7 @@ import {
   createBrandAssetsAsync,
   SourceImageJson,
   SourceBrandAssetsJson,
+  tvosDeploymentTarget,
 } from "../utils";
 import {
   removePortraitOrientation,
@@ -256,5 +258,76 @@ describe("with TV Android tests", () => {
     expect(
       JSON.stringify(modifiedManifest).indexOf("screenOrientation"),
     ).toEqual(-1);
+  });
+});
+
+describe("tvosDeploymentTarget", () => {
+  const configWithBuildProperties = (
+    deploymentTarget: string,
+  ): ExpoConfig => ({
+    name: "test",
+    slug: "test",
+    plugins: [
+      ["expo-build-properties", { ios: { deploymentTarget } }],
+    ],
+  });
+
+  const configWithoutBuildProperties: ExpoConfig = {
+    name: "test",
+    slug: "test",
+    plugins: [["some-other-plugin", {}]],
+  };
+
+  const configWithNoPlugins: ExpoConfig = {
+    name: "test",
+    slug: "test",
+  };
+
+  test("uses plugin param tvosDeploymentTarget when provided", () => {
+    const result = tvosDeploymentTarget(
+      { isTV: true, tvosDeploymentTarget: "16.0" },
+      configWithBuildProperties("17.0"),
+      "18.0",
+    );
+    expect(result).toBe("16.0");
+  });
+
+  test("falls back to expo-build-properties ios.deploymentTarget", () => {
+    const result = tvosDeploymentTarget(
+      { isTV: true },
+      configWithBuildProperties("17.0"),
+      "18.0",
+    );
+    expect(result).toBe("17.0");
+  });
+
+  test("falls back to Expo default iOS deployment target", () => {
+    const result = tvosDeploymentTarget(
+      { isTV: true },
+      configWithoutBuildProperties,
+      "18.0",
+    );
+    expect(result).toBe("18.0");
+  });
+
+  test("falls back to hardcoded default when no config or Expo default", () => {
+    const result = tvosDeploymentTarget({ isTV: true });
+    expect(result).toBe("15.1");
+  });
+
+  test("falls back to hardcoded default when config has no plugins", () => {
+    const result = tvosDeploymentTarget(
+      { isTV: true },
+      configWithNoPlugins,
+    );
+    expect(result).toBe("15.1");
+  });
+
+  test("falls back to hardcoded default when config has no expo-build-properties", () => {
+    const result = tvosDeploymentTarget(
+      { isTV: true },
+      configWithoutBuildProperties,
+    );
+    expect(result).toBe("15.1");
   });
 });

--- a/packages/config-tv/src/utils/config.ts
+++ b/packages/config-tv/src/utils/config.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from "expo/config";
 import { boolish } from "getenv";
 
 import { ConfigData } from "../types";
@@ -21,8 +22,39 @@ export function isTVEnabled(params: ConfigData): boolean {
   return env.EXPO_TV || (params?.isTV ?? false);
 }
 
-export function tvosDeploymentTarget(params: ConfigData): string {
-  return params?.tvosDeploymentTarget ?? defaultTvosDeploymentVersion;
+/**
+ * Returns the iOS deployment target from the expo-build-properties plugin, if present.
+ */
+function iosDeploymentTargetFromBuildProperties(
+  config: ExpoConfig,
+): string | undefined {
+  const plugins = config?.plugins;
+  if (!Array.isArray(plugins)) {
+    return undefined;
+  }
+  for (const plugin of plugins) {
+    if (Array.isArray(plugin) && plugin[0] === "expo-build-properties") {
+      return plugin[1]?.ios?.deploymentTarget;
+    }
+  }
+  return undefined;
+}
+
+export function tvosDeploymentTarget(
+  params: ConfigData,
+  config?: ExpoConfig,
+  expoDefaultIosDeploymentTarget?: string,
+): string {
+  if (params?.tvosDeploymentTarget) {
+    return params.tvosDeploymentTarget;
+  }
+  if (config) {
+    const buildPropsTarget = iosDeploymentTargetFromBuildProperties(config);
+    if (buildPropsTarget) {
+      return buildPropsTarget;
+    }
+  }
+  return expoDefaultIosDeploymentTarget ?? defaultTvosDeploymentVersion;
 }
 
 export function shouldRemoveFlipperOnAndroid(params: ConfigData): boolean {

--- a/packages/config-tv/src/withTVXcodeProject.ts
+++ b/packages/config-tv/src/withTVXcodeProject.ts
@@ -8,12 +8,35 @@ import {
 import { ConfigData } from "./types";
 import { tvosDeploymentTarget, verboseLog } from "./utils";
 
+/**
+ * Reads the existing IPHONEOS_DEPLOYMENT_TARGET from the Xcode project build settings.
+ * This represents Expo's default iOS deployment target as set during prebuild.
+ */
+function getExpoDefaultIosDeploymentTarget(
+  project: XcodeProject,
+): string | undefined {
+  const configurations = project.pbxXCBuildConfigurationSection();
+  // @ts-ignore
+  for (const { buildSettings } of Object.values(configurations || {})) {
+    if (buildSettings?.IPHONEOS_DEPLOYMENT_TARGET) {
+      return buildSettings.IPHONEOS_DEPLOYMENT_TARGET;
+    }
+  }
+  return undefined;
+}
+
 export const withTVXcodeProject: ConfigPlugin<ConfigData> = (
   config,
   params,
 ) => {
-  const deploymentTarget = tvosDeploymentTarget(params);
   return withXcodeProject(config, async (config) => {
+    const expoDefaultIosDeploymentTarget =
+      getExpoDefaultIosDeploymentTarget(config.modResults);
+    const deploymentTarget = tvosDeploymentTarget(
+      params,
+      config,
+      expoDefaultIosDeploymentTarget,
+    );
     config.modResults = await setXcodeProjectBuildSettings(config, {
       project: config.modResults,
       params,


### PR DESCRIPTION
When determining the tvOS deployment target, check the plugin parameter first, then fall back to the iOS deployment target from expo-build-properties, then to Expo's default iOS deployment target from the Xcode project build settings.